### PR TITLE
Ignoring the node modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
If you don't add node_modules to the git ignored files students will not be able to see what changes are dirty in git as they will have lots and lots of node_modules files which should be untracked.  